### PR TITLE
fix .(t)sol path

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ npx locklift test --network local
 You can print to console in contracts with special library:
 
 ```solidity
-import "locklift/src/console.sol";
+import "locklift/src/console.tsol";
 
 contract Sample {
   function testFunc(uint input) external {


### PR DESCRIPTION
This file in node modules has extension .tsol now, but in readme not changed and lead to compilation error.